### PR TITLE
做出了修改：当启用tweakeroo的freecam功能的时候不显示自己的nameTag

### DIFF
--- a/common/src/main/java/org/ayamemc/ayamepaperdoll/hud/PaperDollRenderer.java
+++ b/common/src/main/java/org/ayamemc/ayamepaperdoll/hud/PaperDollRenderer.java
@@ -283,6 +283,12 @@ public class PaperDollRenderer {
         state.shadowPieces.clear();
         state.outlineColor = 0;
 
+        if (state.nameTag != null && minecraft.player != null) {
+            if ( minecraft.player.getName().getString().equals(state.nameTag.getString())) {
+                state.nameTag = null;
+            }
+        }
+
         Quaternionf pose = new Quaternionf().rotateZ((float) Math.PI).rotateY((float) Math.PI);
         Quaternionf configRot = new Quaternionf().rotateXYZ(
                 (float) Math.toRadians(CONFIGS.rotationX.getValue()),


### PR DESCRIPTION
当启用tweakeroo的freecam功能的时候纸娃娃会显示本人的名称，感觉挺别扭的，所以做出了修改，当启用tweakeroo的freecam的时候不显示自己的nameTag。

修改前：
<img width="1394" height="618" alt="image" src="https://github.com/user-attachments/assets/9bfd82a4-e775-4dbb-affa-8133bf8cba37" />

修改后：
<img width="1483" height="551" alt="image" src="https://github.com/user-attachments/assets/e840e333-f7d4-4b44-91e1-4dc1207223ce" />

我并不知道这个是刻意设计的还是没做出适配，如果是没做出适配的话可以考虑这个pr，如果是刻意设计的话那就close吧